### PR TITLE
fix: 修复了带验证码登录账号时route字段不存在而引发的报错

### DIFF
--- a/zfn_api.py
+++ b/zfn_api.py
@@ -169,7 +169,7 @@ class Client:
                 return {"code": 998, "msg": tips.text()}
             self.cookies = self.sess.cookies.get_dict()
             # 不同学校系统兼容差异
-            if not self.cookies.get("route"):
+            if not self.cookies.get("route") and cookies.get("route"):
                 route_cookies = {
                     "JSESSIONID": self.cookies["JSESSIONID"],
                     "route": cookies["route"],


### PR DESCRIPTION
{'code': 999, 'msg': "验证码登录时未记录的错误：'route'"}